### PR TITLE
Use .env file to avoid hard coding client token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Add components in the `src` folder and use them in `src/app.js` to get started.
 ## Usage
 
 1. On GitHub, click the 'use this template' button to create a new repo on your account
-1. Clone the new repo to your computer
-1. Install required dependencies with npm: `npm install`
-1. Start the project: `npm start`
+2. Clone the new repo to your computer
+3. Install required dependencies with npm: `npm install`
+4. Creat a `.env` file and set the value for the client token `REACT_APP_MAPILLARY_CLIENT_TOKEN=MLY|...`
+6. Start the project: `npm start`
 
 Alternatively, if you don't want a new git repo on your account;
 

--- a/src/components/Mapillary/Mapillary.jsx
+++ b/src/components/Mapillary/Mapillary.jsx
@@ -30,7 +30,7 @@ class ViewerComponent extends Component {
 export const Mapillary = (props) => {
   return (
     <ViewerComponent
-      accessToken="MAPILLARY_ACCESS_TOKEN"
+      accessToken={process.env.REACT_APP_MAPILLARY_CLIENT_TOKEN}
       imageId={props.imageId}
       style={{ width: props.width, height: props.height }} />
   );


### PR DESCRIPTION
Here is a suggestion to avoid hard coding the client token. For this to work, you need to define the token in a .env file:
```
REACT_APP_MAPILLARY_CLIENT_TOKEN=MLY|576372...949f7
```